### PR TITLE
make ecr terraform scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The `terraform` folder contains all files for terraform infrastructure:
 - `s3_bucket.tf` - provisioning the AWS S3 bucket for long-term data storage (data older than 24hrs).
   
 One script for each of the 3 ECRs utilised in this project:
-- `dashboard_ecr.tf`
-- `etl_ecr.tf`
-- `data_backup_ecr.tf`
+- `etl_ecr.tf` - contains the image for the `ETL` script which is run every minute
+- `data_backup_ecr.tf` - contains the image for the backup script which moves data to long-term storage every 24hrs. 
+- `dashboard_ecr.tf` - contains the image to run the streamlit dashboard for visualisations
 - Each ECR has a lifecycle policy which keeps only the 30 most recently pushed images.

--- a/README.md
+++ b/README.md
@@ -8,3 +8,15 @@
 ### AWS Architecture Diagram
 
 ![AWS Architecture Diagram](images/architecture_diagram.png)
+
+
+### Terraform Configuration:
+The `terraform` folder contains all files for terraform infrastructure:
+- `provider.tf` - defines the AWS region.
+- `s3_bucket.tf` - provisioning the AWS S3 bucket for long-term data storage (data older than 24hrs).
+  
+One script for each of the 3 ECRs utilised in this project:
+- `dashboard_ecr.tf`
+- `etl_ecr.tf`
+- `data_backup_ecr.tf`
+- Each ECR has a lifecycle policy which keeps only the 30 most recently pushed images.

--- a/terraform/dashboard_ecr.tf
+++ b/terraform/dashboard_ecr.tf
@@ -18,7 +18,6 @@ resource "aws_ecr_lifecycle_policy" "c14_plant_practitioners_dashboard_ecr_lifec
             "description": "Keep last 30 images",
             "selection": {
                 "tagStatus": "tagged",
-                "tagPrefixList": ["v"],
                 "countType": "imageCountMoreThan",
                 "countNumber": 30
             },

--- a/terraform/dashboard_ecr.tf
+++ b/terraform/dashboard_ecr.tf
@@ -1,0 +1,32 @@
+resource "aws_ecr_repository" "c14_plant_practitioners_dashboard_ecr" {
+  name                 = "c14_plant_practitioners_dashboard_ecr"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "c14_plant_practitioners_dashboard_ecr_lifecycle_policy" {
+  repository = aws_ecr_repository.c14_plant_practitioners_dashboard_ecr.name
+
+  policy = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Keep last 30 images",
+            "selection": {
+                "tagStatus": "tagged",
+                "tagPrefixList": ["v"],
+                "countType": "imageCountMoreThan",
+                "countNumber": 30
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
+}

--- a/terraform/data_backup_ecr.tf
+++ b/terraform/data_backup_ecr.tf
@@ -19,7 +19,6 @@ resource "aws_ecr_lifecycle_policy" "c14_plant_practitioners_data_backup_ecr_lif
             "description": "Keep last 30 images",
             "selection": {
                 "tagStatus": "tagged",
-                "tagPrefixList": ["v"],
                 "countType": "imageCountMoreThan",
                 "countNumber": 30
             },

--- a/terraform/data_backup_ecr.tf
+++ b/terraform/data_backup_ecr.tf
@@ -1,0 +1,33 @@
+resource "aws_ecr_repository" "c14_plant_practitioners_data_backup_ecr" {
+  name                 = "c14_plant_practitioners_data_backup_ecr"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+
+resource "aws_ecr_lifecycle_policy" "c14_plant_practitioners_data_backup_ecr_lifecycle_policy" {
+  repository = aws_ecr_repository.c14_plant_practitioners_data_backup_ecr.name
+
+  policy = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Keep last 30 images",
+            "selection": {
+                "tagStatus": "tagged",
+                "tagPrefixList": ["v"],
+                "countType": "imageCountMoreThan",
+                "countNumber": 30
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
+}

--- a/terraform/etl_ecr.tf
+++ b/terraform/etl_ecr.tf
@@ -19,7 +19,6 @@ resource "aws_ecr_lifecycle_policy" "c14_plant_practitioners_etl_ecr_lifecycle_p
             "description": "Keep last 30 images",
             "selection": {
                 "tagStatus": "tagged",
-                "tagPrefixList": ["v"],
                 "countType": "imageCountMoreThan",
                 "countNumber": 30
             },

--- a/terraform/etl_ecr.tf
+++ b/terraform/etl_ecr.tf
@@ -1,0 +1,35 @@
+resource "aws_ecr_repository" "c14_plant_practitioners_etl_ecr" {
+  name                 = "c14_plant_practitioners_etl_ecr"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+
+resource "aws_ecr_lifecycle_policy" "c14_plant_practitioners_etl_ecr_lifecycle_policy" {
+  repository = aws_ecr_repository.c14_plant_practitioners_etl_ecr.name
+
+  policy = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Keep last 30 images",
+            "selection": {
+                "tagStatus": "tagged",
+                "tagPrefixList": ["v"],
+                "countType": "imageCountMoreThan",
+                "countNumber": 30
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
+}
+
+


### PR DESCRIPTION
- Created terraform script to provision each of the 3 ECRs:
- `dashboard_ecr.tf`
- `data_backup_ecr.tf`
- `etl_ecr.tf`
- Included a lifecycle policy within each script which keeps only the latest 30 images pushed to the ECR. (Likely won't affect our project's scope but could be a good consideration for managing storage costs in future)
- Updated ReadMe with basic info on terraform config so far