### PR TITLE
add eventbridge terraform scripts and update terraform readme

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,4 +1,28 @@
-These terraform files implement the following AWS resources:
+### These terraform files implement the following AWS resources:
 
- - **s3_bucket.tf**
-    - "c14-plant-practitioners-long-term-storage" - For long term storage of plant data files as CSVs
+- **`s3_bucket.tf`**
+   - `c14-plant-practitioners-long-term-storage` - For long term storage of plant data files as CSVs
+  
+- **`etl_ecr.tf`**
+  - `c14_plant_practitioners_etl_ecr` - ECR for hosting ETL docker image
+  - `c14_plant_practitioners_etl_ecr_lifecycle_policy` - Lifecycle policy keeping only the 30 latest images pushed to the ECR
+- **`etl_eventbridge_sched.tf`**
+  - `c14_plant_practitioners_etl_lambda_role` - defines the iam role
+  - `c14_plant_practitioners_etl_lambda_function` - defines the Lambda function
+  - `c14_plant_practitioners_etl_rule` - defines the eventbridge rule (every minute)
+  - `c14_plant_practitioners_etl_target` - defines the target for the eventbridge rule
+  - `c14_plant_practitioners_etl_lambda_permission` - allows eventbridge to trigger the lambda function
+  - `c14_plant_practitioners_etl_policy` - defines iam role persmissions
+  - `c14_plant_practitioners_etl_policy_attachment` - attaches iam policy to role
+  
+- **`data_backup_ecr.tf`** 
+  - `c14_plant_practitioners_data_backup_ecr` - ECR for hosting data backup script docker image
+  - `c14_plant_practitioners_data_backup_ecr_lifecycle_policy` - Lifecycle policy keeping only the 30 latest images pushed to the ECR
+  
+- **`data_backup_eventbridge_sched.tf`**
+  - This contains the same resource types as in `etl_eventbridge_sched.tf`, but are separate resource instances for handling the data backup script which is triggered every 24 hours.
+- **`dashboard_ecr.tf`**
+  - `c14_plant_practitioners_dashboard_ecr` - ECR for hosting streamlit dashboard docker image
+- **`ecs_security_group.tf`**
+  - `c14_plant_practitioners_security_group` - security group currently allowing all inbound and outbound traffic 
+- 

--- a/terraform/data_backup_eventbridge_sched.tf
+++ b/terraform/data_backup_eventbridge_sched.tf
@@ -1,0 +1,66 @@
+resource "aws_iam_role" "c14_plant_practitioners_backup_lambda_role" {
+  name = "c14_plant_practitioners_backup_lambda_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "sts:AssumeRole"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_function" "c14_plant_practitioners_backup_lambda_function" {
+  function_name = "c14_plant_practitioners_backup_lambda"
+  role          = aws_iam_role.c14_plant_practitioners_backup_lambda_role.arn
+  package_type  = "Image"
+  image_uri     = "[DOCKER IMAGE URI HERE]"
+  vpc_config {
+    subnet_ids         = ["subnet-0497831b67192adc2", "subnet-0acda1bd2efbf3922", "subnet-0465f224c7432a02e"]  
+    security_group_ids = [aws_security_group.c14_plant_practitioners_security_group.id]
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "c14_plant_practitioners_backup_rule" {
+  name                = "c14_plant_practitioners_backup_rule"
+  description         = "trigger the lambda every 24 hours"
+  schedule_expression = "cron(0 0 * * ? *)"
+
+}
+
+resource "aws_cloudwatch_event_target" "c14_plant_practitioners_backup_target" {
+  rule      = aws_cloudwatch_event_rule.c14_plant_practitioners_backup_rule.name
+  arn       = aws_lambda_function.c14_plant_practitioners_backup_lambda_function.arn
+  role_arn  = aws_iam_role.c14_plant_practitioners_backup_lambda_role.arn
+}
+
+resource "aws_lambda_permission" "c14_plant_practitioners_backup_lambda_permission" {
+  statement_id  = "AllowEventBridgeInvokeDataBackup"
+  action        = "lambda:InvokeFunction"
+  principal     = "events.amazonaws.com"
+  function_name = aws_lambda_function.c14_plant_practitioners_backup_lambda_function.function_name
+  source_arn    = aws_cloudwatch_event_rule.c14_plant_practitioners_backup_rule.arn
+}
+
+resource "aws_iam_policy" "c14_plant_practitioners_backup_policy" {
+  name        = "c14_plant_practitioners_backup_policy"
+  policy      = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:PutObject", "s3:GetObject", "ecs:RunTask"]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "c14_plant_practitioners_backup_policy_attachment" {
+  role       = aws_iam_role.c14_plant_practitioners_backup_lambda_role.name
+  policy_arn = aws_iam_policy.c14_plant_practitioners_backup_policy.arn
+}

--- a/terraform/ecs_security_group.tf
+++ b/terraform/ecs_security_group.tf
@@ -1,0 +1,18 @@
+resource "aws_security_group" "c14_plant_practitioners_security_group" {
+  name        = "c14_plant_practitioners_security_group"
+  vpc_id      = "vpc-0344763624ac09cb6" 
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]  
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"  
+    cidr_blocks = ["0.0.0.0/0"] 
+  }
+}

--- a/terraform/etl_eventbridge_sched.tf
+++ b/terraform/etl_eventbridge_sched.tf
@@ -20,7 +20,7 @@ resource "aws_lambda_function" "c14_plant_practitioners_etl_lambda_function" {
   function_name = "c14_plant_practitioners_etl_lambda"
   role          = aws_iam_role.c14_plant_practitioners_etl_lambda_role.arn
   package_type  = "Image"
-  image_uri     = "[DOCKER IMAGE URI HERE]"
+  image_uri     = "129033205317.dkr.ecr.eu-west-2.amazonaws.com/c14_plant_practitioners_etl_ecr@sha256:772cf4815c027214c9500e9531f844baed040736a2802e1626b4c3d8fb551f7f"
     vpc_config {
     subnet_ids         = ["subnet-0497831b67192adc2", "subnet-0acda1bd2efbf3922", "subnet-0465f224c7432a02e"]  
     security_group_ids = [aws_security_group.c14_plant_practitioners_security_group.id]

--- a/terraform/etl_eventbridge_sched.tf
+++ b/terraform/etl_eventbridge_sched.tf
@@ -1,0 +1,72 @@
+# define iam role
+resource "aws_iam_role" "c14_plant_practitioners_etl_lambda_role" {
+  name = "c14_plant_practitioners_etl_lambda_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "sts:AssumeRole"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+# define lambda function
+resource "aws_lambda_function" "c14_plant_practitioners_etl_lambda_function" {
+  function_name = "c14_plant_practitioners_etl_lambda"
+  role          = aws_iam_role.c14_plant_practitioners_etl_lambda_role.arn
+  package_type  = "Image"
+  image_uri     = "[DOCKER IMAGE URI HERE]"
+    vpc_config {
+    subnet_ids         = ["subnet-0497831b67192adc2", "subnet-0acda1bd2efbf3922", "subnet-0465f224c7432a02e"]  
+    security_group_ids = [aws_security_group.c14_plant_practitioners_security_group.id]
+  }
+}
+
+# create cloudwatch event rule - schedule for the event
+resource "aws_cloudwatch_event_rule" "c14_plant_practitioners_etl_rule" {
+  name                = "c14_plant_practitioners_etl_rule"
+  description         = "trigger the lambda every minute"
+  schedule_expression = "cron(0/1 * * * ? *)"
+}
+
+# eventbridge target for lambda
+resource "aws_cloudwatch_event_target" "c14_plant_practitioners_etl_target" {
+  rule      = aws_cloudwatch_event_rule.c14_plant_practitioners_etl_rule.name
+  arn       = aws_lambda_function.c14_plant_practitioners_etl_lambda_function.arn
+  role_arn  = aws_iam_role.c14_plant_practitioners_etl_lambda_role.arn
+}
+
+# lambda permission - allows eventbridge to trigger lambda
+resource "aws_lambda_permission" "c14_plant_practitioners_etl_lambda_permission" {
+  statement_id  = "AllowEventBridgeInvokeETL"
+  action        = "lambda:InvokeFunction"
+  principal     = "events.amazonaws.com"
+  function_name = aws_lambda_function.c14_plant_practitioners_etl_lambda_function.function_name
+  source_arn    = aws_cloudwatch_event_rule.c14_plant_practitioners_etl_rule.arn
+}
+
+# policy to define permissions
+resource "aws_iam_policy" "c14_plant_practitioners_etl_policy" {
+  name        = "c14_plant_practitioners_etl_policy"
+  policy      = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:PutObject", "s3:GetObject", "ecs:RunTask"]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# attach policy to iam role
+resource "aws_iam_role_policy_attachment" "c14_plant_practitioners_etl_policy_attachment" {
+  role       = aws_iam_role.c14_plant_practitioners_etl_lambda_role.name
+  policy_arn = aws_iam_policy.c14_plant_practitioners_etl_policy.arn
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,10 @@
+variable "access_key_id" {
+  description = "access key for aws"
+  type        = string
+}
+
+variable "secret_access_key" {
+  description = "secret access key for AWS"
+  type        = string
+}
+


### PR DESCRIPTION
#44 
Created 2 eventbridge terraform scripts: 
  1: `etl_eventbridge_sched.tf`
  2: `data_backup_eventbridge_sched.tf`
- Each contains skeleton code for defining the lambda functions (need docker image URI) along with other resources (rule, permission, policy, policy attachment) so should hopefully be good to go once docker images are made. 
- They are virtually identical apart from the cron schedules and resource names
- Also updated README to reflect each resource provisioned in each file
- Made `security_group.tf` for future use which currently allows all inbound and outbound traffic
