### PR TITLE
update terraform config for etl lambda

### DIFF
--- a/terraform/etl_eventbridge_sched.tf
+++ b/terraform/etl_eventbridge_sched.tf
@@ -20,7 +20,9 @@ resource "aws_lambda_function" "c14_plant_practitioners_etl_lambda_function" {
   function_name = "c14_plant_practitioners_etl_lambda"
   role          = aws_iam_role.c14_plant_practitioners_etl_lambda_role.arn
   package_type  = "Image"
-  image_uri     = "129033205317.dkr.ecr.eu-west-2.amazonaws.com/c14_plant_practitioners_etl_ecr@sha256:ca7d0ffe14ffb7bab95a71ffc249c11b107fd3bbdd56f8ae18fc8d2e32d03769"
+  image_uri     = "129033205317.dkr.ecr.eu-west-2.amazonaws.com/c14_plant_practitioners_etl_ecr@sha256:b4026e3b6d925d9112ea4f192e552ba0d40250b67453eb618d9aea1d474464a0"
+  timeout       = 900 
+  memory_size   = 512
   environment {
     variables = {
       DB_HOST            = var.db_host


### PR DESCRIPTION
- increased maximum timeout of lambda to 900s(15 min)
- added memory_size attribute to increase memory to 512MB
- updated URI in config with image for corrected ETL 